### PR TITLE
fix: change CV_BGR2GRAY -> cv::COLOR_BGR2GRAY for opencv 3.x

### DIFF
--- a/src/core/gabor_filter.cpp
+++ b/src/core/gabor_filter.cpp
@@ -51,7 +51,7 @@ void GaborFilter::PreProcessImage(const cv::Mat &src, cv::Mat *result) {
   assert(result);
   cv::Mat resized;
   cv::resize(src, resized, cv::Size(cfg_.image_size, cfg_.image_size));
-  cvtColor(resized, *result, CV_BGR2GRAY);
+  cvtColor(resized, *result, cv::COLOR_BGR2GRAY);
 }
 
 void GaborFilter::EnhanceImage(const cv::Mat &src, cv::Mat *result) {


### PR DESCRIPTION
- fix: change const variable `CV_BGR2GRAY` -> `cv::COLOR_BGR2GRAY`.